### PR TITLE
fix: ERROR 'gbk' codec can't encode character

### DIFF
--- a/yt_dlp_danmaku/__init__.py
+++ b/yt_dlp_danmaku/__init__.py
@@ -89,7 +89,7 @@ class YoutubeDLDanmaku:
 		subtitle['ext'] = 'ass'
 		del subtitle['url']
 		subtitle['data'] = ass
-		with open(new_path, "w", encoding="utf-8") as f:
+		with new_path.open('w', encoding='utf-8') as f:
 			f.write(ass)
 
 		files_to_move = info.get('__files_to_move', {})


### PR DESCRIPTION
> ERROR: 'gbk' codec can't encode character '\u2007' in position 31413: illegal multibyte sequence